### PR TITLE
fix: totalAllocation when at vesting end

### DIFF
--- a/src/vesting/TokenVesting.sol
+++ b/src/vesting/TokenVesting.sol
@@ -115,7 +115,7 @@ contract TokenVesting is Auth {
 
         if (!ve(IVestingFactory(owner).getVe()).isUnlocked()) {
             return 0;
-        } else if (timestamp > start() + duration()) {
+        } else if (timestamp >= start() + duration()) {
             return totalAllocation;
         } else {
             return (totalAllocation * (timestamp - start())) / duration();


### PR DESCRIPTION
This to prevent vestingSchedule function returns more than totalAllocation.